### PR TITLE
Add string algorithm utilities and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+.pytest_cache/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.pytest.ini_options]
+pythonpath = ["src"]

--- a/src/replit_stuff/__init__.py
+++ b/src/replit_stuff/__init__.py
@@ -1,0 +1,9 @@
+"""Utility algorithms and helpers for Replit_Stuff_2025."""
+
+from .string_algorithms import levenshtein_distance, longest_common_subsequence, diff_highlight
+
+__all__ = [
+    "levenshtein_distance",
+    "longest_common_subsequence",
+    "diff_highlight",
+]

--- a/src/replit_stuff/string_algorithms.py
+++ b/src/replit_stuff/string_algorithms.py
@@ -1,0 +1,161 @@
+"""String comparison algorithms used throughout the project.
+
+The module provides a small toolkit with dependable and well tested
+implementations of classic string comparison algorithms:
+
+* :func:`levenshtein_distance` implements the edit distance between two
+  strings using dynamic programming with reduced memory usage.
+* :func:`longest_common_subsequence` computes the longest subsequence that
+  appears in the same relative order in both inputs.
+* :func:`diff_highlight` produces a human friendly diff representation that
+  can be used in logs or user interfaces to highlight how two strings differ.
+
+The functions are designed to be straightforward to use and have comprehensive
+unit tests.  They do not depend on any third-party libraries, making them
+portable and reliable in constrained environments (such as Replit sandboxes).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import List, Sequence
+
+
+def levenshtein_distance(a: str, b: str) -> int:
+    """Return the Levenshtein edit distance between *a* and *b*.
+
+    The implementation uses a dynamic-programming algorithm with linear space
+    complexity.  Only two rows of the DP matrix are kept in memory, making the
+    function suitable for relatively long inputs while remaining easy to
+    understand.
+
+    Args:
+        a: The first string.
+        b: The second string.
+
+    Returns:
+        The minimum number of single-character edits (insertions, deletions or
+        substitutions) required to change *a* into *b*.
+    """
+
+    if not isinstance(a, str) or not isinstance(b, str):  # type: ignore[unreachable]
+        raise TypeError("Both arguments must be strings")
+
+    if a == b:
+        return 0
+
+    if len(a) < len(b):
+        a, b = b, a
+
+    previous_row: List[int] = list(range(len(b) + 1))
+    for i, char_a in enumerate(a, start=1):
+        current_row = [i]
+        for j, char_b in enumerate(b, start=1):
+            insertion = current_row[j - 1] + 1
+            deletion = previous_row[j] + 1
+            substitution = previous_row[j - 1] + (char_a != char_b)
+            current_row.append(min(insertion, deletion, substitution))
+        previous_row = current_row
+    return previous_row[-1]
+
+
+def longest_common_subsequence(a: str, b: str) -> str:
+    """Return the longest common subsequence of *a* and *b*.
+
+    When multiple subsequences have the same maximum length the
+    lexicographically smallest subsequence is returned.  The implementation uses
+    memoised recursion which keeps the code compact while still being efficient
+    for typical input sizes.
+    """
+
+    if not isinstance(a, str) or not isinstance(b, str):  # type: ignore[unreachable]
+        raise TypeError("Both arguments must be strings")
+
+    @lru_cache(maxsize=None)
+    def helper(i: int, j: int) -> str:
+        if i == len(a) or j == len(b):
+            return ""
+        if a[i] == b[j]:
+            return a[i] + helper(i + 1, j + 1)
+
+        option1 = helper(i + 1, j)
+        option2 = helper(i, j + 1)
+        if len(option1) > len(option2):
+            return option1
+        if len(option2) > len(option1):
+            return option2
+        return min(option1, option2)
+
+    return helper(0, 0)
+
+
+@dataclass(frozen=True)
+class DiffOp:
+    """A representation of a single diff operation."""
+
+    tag: str
+    text: str
+
+    def __post_init__(self) -> None:
+        if self.tag not in {"equal", "insert", "delete"}:
+            raise ValueError(f"Invalid diff tag: {self.tag}")
+
+
+def diff_highlight(a: str, b: str) -> List[DiffOp]:
+    """Produce a simple diff between *a* and *b*.
+
+    The function returns a list of :class:`DiffOp` instances describing how to
+    transform *a* into *b*.  It is intentionally limited compared to the
+    :mod:`difflib` module but produces cleaner output for short strings.
+    """
+
+    if not isinstance(a, str) or not isinstance(b, str):  # type: ignore[unreachable]
+        raise TypeError("Both arguments must be strings")
+
+    if a == b:
+        return [DiffOp("equal", a)] if a else []
+
+    lcs = longest_common_subsequence(a, b)
+
+    ops: List[DiffOp] = []
+    i = j = k = 0
+    while k < len(lcs):
+        target = lcs[k]
+        while i < len(a) and a[i] != target:
+            ops.append(DiffOp("delete", a[i]))
+            i += 1
+        while j < len(b) and b[j] != target:
+            ops.append(DiffOp("insert", b[j]))
+            j += 1
+        ops.append(DiffOp("equal", target))
+        i += 1
+        j += 1
+        k += 1
+
+    if i < len(a):
+        ops.append(DiffOp("delete", a[i:]))
+    if j < len(b):
+        ops.append(DiffOp("insert", b[j:]))
+
+    return _merge_adjacent_ops(ops)
+
+
+def _merge_adjacent_ops(ops: Sequence[DiffOp]) -> List[DiffOp]:
+    """Merge neighbouring operations with the same tag."""
+
+    merged: List[DiffOp] = []
+    for op in ops:
+        if merged and merged[-1].tag == op.tag:
+            merged[-1] = DiffOp(merged[-1].tag, merged[-1].text + op.text)
+        else:
+            merged.append(op)
+    return merged
+
+
+__all__ = [
+    "DiffOp",
+    "diff_highlight",
+    "levenshtein_distance",
+    "longest_common_subsequence",
+]

--- a/tests/test_string_algorithms.py
+++ b/tests/test_string_algorithms.py
@@ -1,0 +1,63 @@
+import pytest
+
+from replit_stuff.string_algorithms import (
+    DiffOp,
+    diff_highlight,
+    levenshtein_distance,
+    longest_common_subsequence,
+)
+
+
+def test_levenshtein_distance_basic():
+    assert levenshtein_distance("kitten", "sitting") == 3
+    assert levenshtein_distance("", "") == 0
+    assert levenshtein_distance("abc", "abc") == 0
+    assert levenshtein_distance("flaw", "lawn") == 2
+
+
+def test_levenshtein_distance_type_error():
+    with pytest.raises(TypeError):
+        levenshtein_distance(123, "abc")  # type: ignore[arg-type]
+
+
+def test_longest_common_subsequence():
+    assert longest_common_subsequence("abcde", "ace") == "ace"
+    assert longest_common_subsequence("abc", "def") == ""
+    assert longest_common_subsequence("aaaa", "aa") == "aa"
+    # tie breaking
+    assert longest_common_subsequence("zab", "zba") == "za"
+
+
+def test_diff_highlight_equal():
+    assert diff_highlight("hello", "hello") == [DiffOp("equal", "hello")]
+    assert diff_highlight("", "") == []
+
+
+def test_diff_highlight_insert_delete():
+    ops = diff_highlight("cat", "cart")
+    assert ops == [DiffOp("equal", "ca"), DiffOp("insert", "r"), DiffOp("equal", "t")]
+
+    ops = diff_highlight("spore", "sore")
+    assert ops == [DiffOp("equal", "s"), DiffOp("delete", "p"), DiffOp("equal", "ore")]
+
+
+def test_diff_highlight_complex():
+    ops = diff_highlight("abcd", "azced")
+    assert ops == [
+        DiffOp("equal", "a"),
+        DiffOp("delete", "b"),
+        DiffOp("insert", "z"),
+        DiffOp("equal", "c"),
+        DiffOp("insert", "e"),
+        DiffOp("equal", "d"),
+    ]
+
+
+def test_diff_highlight_type_error():
+    with pytest.raises(TypeError):
+        diff_highlight(1, "abc")  # type: ignore[arg-type]
+
+
+def test_diff_highlight_merge_adjacent():
+    ops = diff_highlight("abc", "xyz")
+    assert ops == [DiffOp("delete", "abc"), DiffOp("insert", "xyz")]


### PR DESCRIPTION
## Summary
- add a reusable string algorithms module with Levenshtein distance, LCS and diff helpers
- expose the algorithms via the package __init__ for convenient imports
- configure pytest to find the new sources and add thorough unit test coverage

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e01a7a1bb0832691144d733c756696